### PR TITLE
update travis.yml

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,16 +2,10 @@
 language: ruby
 
 rvm:
-  - 1.8.7
-  - 1.9.3
-  - 2.0.0
-  - 2.1.0
+  - 2.1
 
 env:
   matrix:
-    - PUPPET_GEM_VERSION="~> 3.1.0"
-    - PUPPET_GEM_VERSION="~> 3.2.0"
-    - PUPPET_GEM_VERSION="~> 3.3.0"
     - PUPPET_GEM_VERSION="~> 3.4.0"
     - PUPPET_GEM_VERSION="~> 3.5.1"
     - PUPPET_GEM_VERSION="~> 3.6.0"
@@ -25,8 +19,6 @@ script: 'bundle exec metadata-json-lint metadata.json && bundle exec rake valida
 matrix:
   fast_finish: true
   exclude:
-    - rvm: 2.0.0
-      env: PUPPET_GEM_VERSION="~> 3.1.0"
     - rvm: 2.1.0
       env: PUPPET_GEM_VERSION="~> 3.1.0"
     - rvm: 2.1.0


### PR DESCRIPTION
Tests for really old ruby versions were failing. I don't really know what the future of this module will be after we get ourselves on even higher versions of puppet and the surrounding modules so rather than spending effort on this I'm just removing those versions from the `.travis.yml`

Tests pass now.